### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Discord Bot CI/CD
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/Gaute945/Overmounting/security/code-scanning/1](https://github.com/Gaute945/Overmounting/security/code-scanning/1)

To remediate the problem, add a `permissions:` key to scope the `GITHUB_TOKEN` used in this workflow to the minimum required permissions. The job shown only installs dependencies and checks syntax, and does not interact with the repository or perform GitHub API operations needing write access, so `contents: read` is the minimal required permission. You can add the `permissions:` block at the root of the workflow (just below the `name:`), so all jobs inherit it, or within the individual job. The most maintainable and standard practice is to add it at the workflow root. 

Specifically, insert the following lines after the `name:` line and before `on:`:

```yaml
permissions:
  contents: read
``` 

No other imports, methods, or configuration are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
